### PR TITLE
docs: add a new step to highlight the last step

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -50,7 +50,8 @@ prereqs:
 3. `./scripts/create-gh-release.sh <RELEASE_TAG>`
     - This step creates a pull request with the release `RELEASE_TAG` changes
       and creates a GitHub draft release. It outputs the URLs for each at the
-      end of the script execution for manual merging and publishing when ready.
+      end of the script execution for manual merging.
+4. Once the pull request is merged, **publish the `draft` release** when ready.
 
 ### Manual
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Documentation: We need to highlight the last step of the releasing `automated` instructions. Perhaps we could automatize this step in the future.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
